### PR TITLE
Changed the naming in the second content array

### DIFF
--- a/standard/example1/sequence_diagram.json
+++ b/standard/example1/sequence_diagram.json
@@ -59,13 +59,13 @@
       "node" : "seq",
       "content" : [
         {
-          "type" : "send",
+          "node" : "send",
           "from" : "u3",
           "to" : "g",
           "message" : ["status"]
         },
         {
-          "type" : "send",
+          "node" : "send",
           "from" : "g",
           "to" : "u3",
           "message" : ["ok"]


### PR DESCRIPTION
Changed to "node" from "type" in two instances in the second content array in the diagram. This change makes the diagram consistent with the other examples we have been provided with